### PR TITLE
Add UniRate as a price source

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ pipx install pricehist
 - **`coindesk`**: [CoinDesk Bitcoin Price Index](https://www.coindesk.com/coindesk-api)
 - **`coinmarketcap`**: [CoinMarketCap](https://coinmarketcap.com/)
 - **`ecb`**: [European Central Bank Euro foreign exchange reference rates](https://www.ecb.europa.eu/stats/exchange/eurofxref/html/index.en.html)
+- **`unirate`**: [UniRate API](https://unirateapi.com/) (paid plan required for historical data)
 - **`yahoo`**: [Yahoo! Finance](https://finance.yahoo.com/)
 
 ## Output formats

--- a/src/pricehist/beanprice/unirate.py
+++ b/src/pricehist/beanprice/unirate.py
@@ -1,0 +1,4 @@
+from pricehist import beanprice
+from pricehist.sources.unirate import UniRate
+
+Source = beanprice.source(UniRate())

--- a/src/pricehist/sources/__init__.py
+++ b/src/pricehist/sources/__init__.py
@@ -4,6 +4,7 @@ from .coinbasepro import CoinbasePro
 from .coindesk import CoinDesk
 from .coinmarketcap import CoinMarketCap
 from .ecb import ECB
+from .unirate import UniRate
 from .yahoo import Yahoo
 
 by_id = {
@@ -15,6 +16,7 @@ by_id = {
         CoinDesk(),
         CoinMarketCap(),
         ECB(),
+        UniRate(),
         Yahoo(),
     ]
 }

--- a/src/pricehist/sources/unirate.py
+++ b/src/pricehist/sources/unirate.py
@@ -1,0 +1,145 @@
+import dataclasses
+import json
+import os
+from datetime import date, timedelta
+from decimal import Decimal
+
+import requests
+
+from pricehist import exceptions
+from pricehist.price import Price
+
+from .basesource import BaseSource
+
+
+class UniRate(BaseSource):
+    API_URL = "https://api.unirateapi.com/api"
+    API_KEY_NAME = "UNIRATE_API_KEY"
+    CHUNK_DAYS = 1800  # API accepts up to 5 years (~1825 days) per request
+
+    def id(self):
+        return "unirate"
+
+    def name(self):
+        return "UniRate API"
+
+    def description(self):
+        return (
+            "Current and historical foreign exchange rates covering 170+ "
+            "fiat and crypto currencies"
+        )
+
+    def source_url(self):
+        return "https://unirateapi.com/"
+
+    def start(self):
+        return "1999-01-01"
+
+    def types(self):
+        return ["reference"]
+
+    def notes(self):
+        keystatus = "already set" if self._apikey(require=False) else "not yet set"
+        return (
+            "UniRate API provides current and historical exchange rates for "
+            "170+ currencies. Historical data (used by pricehist) requires a "
+            "paid plan; current rates and the currency list are available on "
+            "the free tier.\n"
+            f"Set your API key in the {self.API_KEY_NAME} environment variable "
+            f"({keystatus}). Sign up at https://unirateapi.com/ to obtain one.\n"
+            "Historical coverage varies by currency; USD pairs go back to "
+            "1999. Rates are daily reference rates; only the 'reference' "
+            "price type is available."
+        )
+
+    def symbols(self):
+        data = self._get_json("currencies", {})
+        currencies = data.get("currencies") or []
+        if not currencies:
+            raise exceptions.ResponseParsingError("Expected data not found")
+        return [(c, c) for c in sorted(currencies)]
+
+    def fetch(self, series):
+        if not series.base or not series.quote:
+            raise exceptions.InvalidPair(series.base, series.quote, self)
+
+        all_prices = []
+        for chunk_start, chunk_end in self._chunks(series.start, series.end):
+            data = self._get_json(
+                "historical/timeseries",
+                {
+                    "start_date": chunk_start,
+                    "end_date": chunk_end,
+                    "base": series.base,
+                    "currencies": series.quote,
+                },
+            )
+            daily = data.get("data") or {}
+            for day, entries in daily.items():
+                if series.quote in entries:
+                    all_prices.append(Price(day, Decimal(str(entries[series.quote]))))
+
+        if not all_prices:
+            raise exceptions.InvalidPair(
+                series.base,
+                series.quote,
+                self,
+                "No data returned for the requested pair and interval.",
+            )
+
+        all_prices.sort(key=lambda p: p.date)
+        return dataclasses.replace(series, prices=all_prices)
+
+    def _chunks(self, start, end):
+        """Yield (start, end) ISO-date strings no longer than CHUNK_DAYS."""
+        start_d = date.fromisoformat(start)
+        end_d = date.fromisoformat(end)
+        if end_d < start_d:
+            return
+        cursor = start_d
+        step = timedelta(days=self.CHUNK_DAYS - 1)
+        while cursor <= end_d:
+            chunk_end = min(cursor + step, end_d)
+            yield cursor.isoformat(), chunk_end.isoformat()
+            cursor = chunk_end + timedelta(days=1)
+
+    def _get_json(self, path, params):
+        params = {**params, "api_key": self._apikey()}
+
+        try:
+            response = self.log_curl(
+                requests.get(
+                    f"{self.API_URL}/{path}",
+                    params=params,
+                    headers={"Accept": "application/json"},
+                )
+            )
+        except Exception as e:
+            raise exceptions.RequestError(str(e)) from e
+
+        if response.status_code == 401:
+            raise exceptions.CredentialsError([self.API_KEY_NAME], self)
+        if response.status_code == 403:
+            raise exceptions.CredentialsError(
+                [self.API_KEY_NAME],
+                self,
+                "This endpoint requires a paid UniRate plan.",
+            )
+        if response.status_code == 429:
+            raise exceptions.RateLimit(response.text or "Rate limit reached.")
+
+        try:
+            response.raise_for_status()
+        except Exception as e:
+            raise exceptions.BadResponse(str(e)) from e
+
+        try:
+            return json.loads(response.content, parse_float=Decimal)
+        except Exception as e:
+            raise exceptions.ResponseParsingError(str(e)) from e
+
+    def _apikey(self, require=True):
+        key = os.getenv(self.API_KEY_NAME)
+        if require and not key:
+            raise exceptions.CredentialsError([self.API_KEY_NAME], self)
+        return key

--- a/tests/pricehist/sources/test_unirate.py
+++ b/tests/pricehist/sources/test_unirate.py
@@ -1,0 +1,224 @@
+import json
+import logging
+from datetime import datetime
+from decimal import Decimal
+
+import pytest
+import requests
+import responses
+
+from pricehist import exceptions
+from pricehist.price import Price
+from pricehist.series import Series
+from pricehist.sources.unirate import UniRate
+
+
+@pytest.fixture
+def src():
+    return UniRate()
+
+
+@pytest.fixture
+def type(src):
+    return src.types()[0]
+
+
+@pytest.fixture(autouse=True)
+def api_key(monkeypatch):
+    monkeypatch.setenv(UniRate.API_KEY_NAME, "test-key")
+
+
+@pytest.fixture
+def currencies_url():
+    return "https://api.unirateapi.com/api/currencies"
+
+
+@pytest.fixture
+def timeseries_url():
+    return "https://api.unirateapi.com/api/historical/timeseries"
+
+
+@pytest.fixture
+def requests_mock():
+    with responses.RequestsMock() as mock:
+        yield mock
+
+
+@pytest.fixture
+def currencies_body():
+    return json.dumps({"currencies": ["USD", "EUR", "GBP", "JPY"]})
+
+
+@pytest.fixture
+def timeseries_body():
+    return json.dumps(
+        {
+            "amount": 1,
+            "base": "USD",
+            "start_date": "2024-01-01",
+            "end_date": "2024-01-05",
+            "total_days": 5,
+            "currencies": ["EUR"],
+            "data": {
+                "2024-01-01": {"EUR": 0.9050},
+                "2024-01-02": {"EUR": 0.9072},
+                "2024-01-03": {"EUR": 0.9103},
+                "2024-01-04": {"EUR": 0.9128},
+                "2024-01-05": {"EUR": 0.9115},
+            },
+        }
+    )
+
+
+def test_normalizesymbol(src):
+    assert src.normalizesymbol("eur") == "EUR"
+    assert src.normalizesymbol("usd") == "USD"
+
+
+def test_metadata(src):
+    assert isinstance(src.id(), str) and len(src.id()) > 0
+    assert isinstance(src.name(), str) and len(src.name()) > 0
+    assert isinstance(src.description(), str) and len(src.description()) > 0
+    assert src.source_url().startswith("http")
+    assert datetime.strptime(src.start(), "%Y-%m-%d")
+    assert isinstance(src.types(), list) and len(src.types()) > 0
+    assert isinstance(src.notes(), str)
+
+
+def test_symbols(src, requests_mock, currencies_url, currencies_body):
+    requests_mock.add(responses.GET, currencies_url, body=currencies_body, status=200)
+    syms = src.symbols()
+    assert ("EUR", "EUR") in syms
+    assert ("USD", "USD") in syms
+    assert syms == sorted(syms)
+
+
+def test_symbols_requests_logged(
+    src, requests_mock, currencies_url, currencies_body, caplog
+):
+    requests_mock.add(responses.GET, currencies_url, body=currencies_body, status=200)
+    with caplog.at_level(logging.DEBUG):
+        src.symbols()
+    assert any(
+        ["DEBUG" == r.levelname and "curl " in r.message for r in caplog.records]
+    )
+
+
+def test_symbols_empty(src, requests_mock, currencies_url):
+    requests_mock.add(
+        responses.GET, currencies_url, body=json.dumps({"currencies": []}), status=200
+    )
+    with pytest.raises(exceptions.ResponseParsingError):
+        src.symbols()
+
+
+def test_fetch_known_pair(src, type, requests_mock, timeseries_url, timeseries_body):
+    requests_mock.add(responses.GET, timeseries_url, body=timeseries_body, status=200)
+    series = src.fetch(Series("USD", "EUR", type, "2024-01-01", "2024-01-05"))
+    assert series.prices[0] == Price("2024-01-01", Decimal("0.9050"))
+    assert series.prices[-1] == Price("2024-01-05", Decimal("0.9115"))
+    assert len(series.prices) == 5
+
+
+def test_fetch_multi_chunk(src, type, requests_mock, timeseries_url):
+    chunk_a = json.dumps(
+        {"data": {"2015-01-01": {"EUR": 0.83}, "2015-06-01": {"EUR": 0.90}}}
+    )
+    chunk_b = json.dumps(
+        {"data": {"2021-01-01": {"EUR": 0.81}, "2021-06-01": {"EUR": 0.82}}}
+    )
+    requests_mock.add(responses.GET, timeseries_url, body=chunk_a, status=200)
+    requests_mock.add(responses.GET, timeseries_url, body=chunk_b, status=200)
+
+    series = src.fetch(Series("USD", "EUR", type, "2015-01-01", "2021-06-01"))
+    assert len(requests_mock.calls) == 2
+    dates = [p.date for p in series.prices]
+    assert dates == sorted(dates)
+    assert len(series.prices) == 4
+
+
+def test_fetch_no_api_key(src, type, monkeypatch):
+    monkeypatch.delenv(UniRate.API_KEY_NAME, raising=False)
+    with pytest.raises(exceptions.CredentialsError):
+        src.fetch(Series("USD", "EUR", type, "2024-01-01", "2024-01-05"))
+
+
+def test_fetch_403_pro_gated(src, type, requests_mock, timeseries_url):
+    requests_mock.add(responses.GET, timeseries_url, body="Forbidden", status=403)
+    with pytest.raises(exceptions.CredentialsError) as e:
+        src.fetch(Series("USD", "EUR", type, "2024-01-01", "2024-01-05"))
+    assert "paid" in str(e.value).lower()
+
+
+def test_fetch_401_bad_key(src, type, requests_mock, timeseries_url):
+    requests_mock.add(responses.GET, timeseries_url, body="Unauthorized", status=401)
+    with pytest.raises(exceptions.CredentialsError):
+        src.fetch(Series("USD", "EUR", type, "2024-01-01", "2024-01-05"))
+
+
+def test_fetch_rate_limit(src, type, requests_mock, timeseries_url):
+    requests_mock.add(responses.GET, timeseries_url, body="Too many", status=429)
+    with pytest.raises(exceptions.RateLimit):
+        src.fetch(Series("USD", "EUR", type, "2024-01-01", "2024-01-05"))
+
+
+def test_fetch_empty_data_invalid_pair(src, type, requests_mock, timeseries_url):
+    requests_mock.add(
+        responses.GET, timeseries_url, body=json.dumps({"data": {}}), status=200
+    )
+    with pytest.raises(exceptions.InvalidPair):
+        src.fetch(Series("USD", "XZY", type, "2024-01-01", "2024-01-05"))
+
+
+def test_fetch_no_quote(src, type):
+    with pytest.raises(exceptions.InvalidPair):
+        src.fetch(Series("USD", "", type, "2024-01-01", "2024-01-05"))
+
+
+def test_fetch_network_issue(src, type, requests_mock, timeseries_url):
+    err = requests.exceptions.ConnectionError("Network issue")
+    requests_mock.add(responses.GET, timeseries_url, body=err)
+    with pytest.raises(exceptions.RequestError) as e:
+        src.fetch(Series("USD", "EUR", type, "2024-01-01", "2024-01-05"))
+    assert "Network issue" in str(e.value)
+
+
+def test_fetch_bad_status(src, type, requests_mock, timeseries_url):
+    requests_mock.add(responses.GET, timeseries_url, status=500)
+    with pytest.raises(exceptions.BadResponse):
+        src.fetch(Series("USD", "EUR", type, "2024-01-01", "2024-01-05"))
+
+
+def test_fetch_parsing_error(src, type, requests_mock, timeseries_url):
+    requests_mock.add(responses.GET, timeseries_url, body="NOT JSON", status=200)
+    with pytest.raises(exceptions.ResponseParsingError):
+        src.fetch(Series("USD", "EUR", type, "2024-01-01", "2024-01-05"))
+
+
+def test_fetch_sends_api_key_and_accept(
+    src, type, requests_mock, timeseries_url, timeseries_body
+):
+    requests_mock.add(responses.GET, timeseries_url, body=timeseries_body, status=200)
+    src.fetch(Series("USD", "EUR", type, "2024-01-01", "2024-01-05"))
+    call = requests_mock.calls[0].request
+    assert "api_key=test-key" in call.url
+    assert call.headers.get("Accept") == "application/json"
+
+
+def test_chunks_single(src):
+    chunks = list(src._chunks("2024-01-01", "2024-01-10"))
+    assert chunks == [("2024-01-01", "2024-01-10")]
+
+
+def test_chunks_multi(src):
+    chunks = list(src._chunks("2000-01-01", "2020-01-01"))
+    assert len(chunks) >= 4
+    assert chunks[0][0] == "2000-01-01"
+    assert chunks[-1][1] == "2020-01-01"
+    # chunks should be contiguous and non-overlapping
+    for (s1, e1), (s2, _) in zip(chunks, chunks[1:]):
+        assert datetime.fromisoformat(s2) > datetime.fromisoformat(e1)
+
+
+def test_chunks_inverted_range(src):
+    assert list(src._chunks("2024-01-10", "2024-01-01")) == []


### PR DESCRIPTION
Adds [UniRate API](https://unirateapi.com/) as a price source for foreign-exchange data covering 170+ fiat and cryptocurrency pairs.

### What's included

- `src/pricehist/sources/unirate.py` — implements `BaseSource`. Uses the `/api/historical/timeseries` endpoint and chunks requests to stay within the provider's 5-year-per-call limit.
- `src/pricehist/beanprice/unirate.py` — one-liner beanprice adapter, matches the pattern used by the other sources.
- `tests/pricehist/sources/test_unirate.py` — 20 mock tests covering metadata, `symbols()`, `fetch()` across single and multi-chunk date ranges, and the full error taxonomy:
  - `CredentialsError` on missing `UNIRATE_API_KEY`, HTTP 401, and HTTP 403 (the distinct "paid plan required" case)
  - `RateLimit` on HTTP 429
  - `RequestError` / `BadResponse` / `ResponseParsingError` on the usual network and parsing failures
  - `InvalidPair` when the response contains no data for the requested pair
- `README.md` — lists the new source with a note that historical data requires a paid plan.

### Notes

- Historical data is on a paid tier at UniRate. The currency list and current rates are free; pricehist only needs historical, so an API key is required. This is surfaced in `notes()` and enforced in `_apikey()`.
- Only the `reference` price type is provided — UniRate returns one rate per day.
- `normalizesymbol` uses the default (uppercase), which matches UniRate's normalization.
- Full test suite runs green locally (307 passed), lint clean with `black` / `flake8` / `isort`.

### Verification

```bash
pricehist sources           # unirate appears in the list
pricehist source unirate    # metadata prints with the API-key note
UNIRATE_API_KEY=... pricehist fetch unirate USD/EUR -s 2024-01-01 -e 2024-01-05
```

Happy to also open this as a GitLab MR if that's your preferred location — just let me know.
